### PR TITLE
fix: data race.

### DIFF
--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -39,10 +39,10 @@ type runner struct {
 
 func NewRun(pkgs ...string) func(pass *analysis.Pass) (interface{}, error) {
 	return func(pass *analysis.Pass) (interface{}, error) {
-		pkgs = append(pkgs, "database/sql")
-		for _, pkg := range pkgs {
+		sqlPkgs := append(pkgs, "database/sql")
+		for _, pkg := range sqlPkgs {
 			r := new(runner)
-			r.sqlPkgs = pkgs
+			r.sqlPkgs = sqlPkgs
 			r.run(pass, pkg)
 		}
 		return nil, nil


### PR DESCRIPTION
related to a problem detected in golangci-lint:



```console
$ make test_race
go build -race -o golangci-lint ./cmd/golangci-lint
GL_TEST_RUN=1 ./golangci-lint run -v --timeout=5m
INFO [config_reader] Config search paths: [./ /home/ldez/sources/go/src/github.com/golangci/golangci-lint /home/ldez/sources/go/src/github.com/golangci /home/ldez/sources/go/src/github.com /home/ldez/sources/go/src /home/ldez/sources/go /home/ldez/sources /home/ldez /home /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 38 linters: [bodyclose deadcode depguard dogsled dupl errcheck exhaustive funlen gochecknoinits goconst gocritic gocyclo gofmt goimports golint gomnd goprintffuncname gosec gosimple govet ineffassign interfacer lll misspell nakedret noctx nolintlint rowserrcheck scopelint staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [lintersdb] Active 38 linters: [bodyclose deadcode depguard dogsled dupl errcheck exhaustive funlen gochecknoinits goconst gocritic gocyclo gofmt goimports golint gomnd goprintffuncname gosec gosimple govet ineffassign interfacer lll misspell nakedret noctx nolintlint rowserrcheck scopelint staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [loader] Go packages loading at mode 575 (deps|imports|types_sizes|compiled_files|files|name|exports_file) took 1.805497827s 
INFO [lintersdb] Active 38 linters: [bodyclose deadcode depguard dogsled dupl errcheck exhaustive funlen gochecknoinits goconst gocritic gocyclo gofmt goimports golint gomnd goprintffuncname gosec gosimple govet ineffassign interfacer lll misspell nakedret noctx nolintlint rowserrcheck scopelint staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 117.255579ms 
==================
WARNING: DATA RACE
Read at 0x00c000950040 by goroutine 2224:
  github.com/jingyugao/rowserrcheck/passes/rowserr.NewRun.func1()
      /home/ldez/sources/go/pkg/mod/github.com/jingyugao/rowserrcheck@v0.0.0-20191204022205-72ab7603b68a/passes/rowserr/rowserr.go:42 +0x67
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:590 +0x15e9
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:512 +0x44
  github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x61
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:511 +0x145
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1059 +0x7a

Previous write at 0x00c000950040 by goroutine 3112:
  [failed to restore the stack]

Goroutine 2224 (running) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a

Goroutine 3112 (finished) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a
==================
==================
WARNING: DATA RACE
Read at 0x00c002a2c560 by goroutine 2224:
  github.com/jingyugao/rowserrcheck/passes/rowserr.NewRun.func1()
      /home/ldez/sources/go/pkg/mod/github.com/jingyugao/rowserrcheck@v0.0.0-20191204022205-72ab7603b68a/passes/rowserr/rowserr.go:43 +0x19c
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:590 +0x15e9
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:512 +0x44
  github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x61
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:511 +0x145
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1059 +0x7a

Previous write at 0x00c002a2c560 by goroutine 3112:
  [failed to restore the stack]

Goroutine 2224 (running) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a

Goroutine 3112 (finished) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a
==================
==================
WARNING: DATA RACE
Read at 0x00c016aca690 by goroutine 2055:
  github.com/jingyugao/rowserrcheck/passes/rowserr.NewRun.func1()
      /home/ldez/sources/go/pkg/mod/github.com/jingyugao/rowserrcheck@v0.0.0-20191204022205-72ab7603b68a/passes/rowserr/rowserr.go:43 +0x19c
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:590 +0x15e9
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:512 +0x44
  github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x61
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:511 +0x145
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1059 +0x7a

Previous write at 0x00c016aca690 by goroutine 2934:
  github.com/jingyugao/rowserrcheck/passes/rowserr.NewRun.func1()
      /home/ldez/sources/go/pkg/mod/github.com/jingyugao/rowserrcheck@v0.0.0-20191204022205-72ab7603b68a/passes/rowserr/rowserr.go:42 +0xc4
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:590 +0x15e9
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:512 +0x44
  github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x61
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:511 +0x145
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1059 +0x7a

Goroutine 2055 (running) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a

Goroutine 2934 (finished) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a
==================
==================
WARNING: DATA RACE
Read at 0x00c016aca6f0 by goroutine 675:
  runtime.growslice()
      /home/ldez/.gvm/gos/go1.15.7/src/runtime/slice.go:125 +0x0
  github.com/jingyugao/rowserrcheck/passes/rowserr.NewRun.func1()
      /home/ldez/sources/go/pkg/mod/github.com/jingyugao/rowserrcheck@v0.0.0-20191204022205-72ab7603b68a/passes/rowserr/rowserr.go:42 +0x30c
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:590 +0x15e9
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:512 +0x44
  github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x61
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:511 +0x145
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1059 +0x7a

Previous write at 0x00c016aca6f0 by goroutine 3626:
  github.com/jingyugao/rowserrcheck/passes/rowserr.NewRun.func1()
      /home/ldez/sources/go/pkg/mod/github.com/jingyugao/rowserrcheck@v0.0.0-20191204022205-72ab7603b68a/passes/rowserr/rowserr.go:42 +0xc4
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:590 +0x15e9
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:512 +0x44
  github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x61
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:511 +0x145
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1059 +0x7a

Goroutine 675 (running) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a

Goroutine 3626 (finished) created at:
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x444
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive.func1()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1027 +0x215
  sync.(*Once).doSlow()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /home/ldez/.gvm/gos/go1.15.7/src/sync/once.go:57 +0x68
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyzeRecursive()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:1016 +0x7e
  github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*runner).analyze.func2()
      /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go:317 +0x6a
==================
INFO [linters context/goanalysis] analyzers took 12m57.729004294s with top 10 stages: buildir: 1m23.934498435s, exhaustive: 23.497495713s, whitespace: 11.174981255s, mnd: 10.959288269s, gosec: 10.833934474s, gocritic: 9.472046931s, golint: 9.053576927s, goimports: 8.621700603s, printf: 7.556060423s, inspect: 7.482519705s 
INFO [linters context/goanalysis] analyzers took 8.804465458s with top 10 stages: U1000: 5.360989283s, buildir: 3.443476175s 
INFO [runner/skip dirs] Skipped 15 issues from dir internal/renameio by pattern internal/renameio 
INFO [runner/skip dirs] Skipped 77 issues from dir internal/cache by pattern internal/cache 
INFO [runner/skip dirs] Skipped 3 issues from dir test/testdata_etc/unused_exported by pattern test/testdata_etc 
INFO [runner/skip dirs] Skipped 2 issues from dir internal/robustio by pattern internal/robustio 
INFO [runner/skip dirs] Skipped 3 issues from dir test/testdata_etc/unused_exported/lib by pattern test/testdata_etc 
INFO [runner/skip dirs] Skipped 5 issues from dir test/testdata_etc/abspath by pattern test/testdata_etc 
INFO [runner] Issues before processing: 970, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 865/865, exclude: 865/865, skip_files: 970/970, skip_dirs: 865/970, cgo: 970/970, filename_unadjuster: 970/970, path_prettifier: 970/970, identifier_marker: 865/865, exclude-rules: 115/865, nolint: 0/115 
INFO [runner] processing took 877.01494ms with stages: identifier_marker: 374.410284ms, exclude-rules: 292.769687ms, nolint: 172.188457ms, path_prettifier: 19.783342ms, skip_dirs: 8.356415ms, autogenerated_exclude: 7.939973ms, cgo: 828.898µs, filename_unadjuster: 722.468µs, max_same_issues: 2.878µs, skip_files: 1.986µs, exclude: 1.581µs, max_from_linter: 1.503µs, uniq_by_line: 1.404µs, sort_results: 1.073µs, diff: 994ns, source_code: 931ns, path_shortener: 854ns, severity-rules: 845ns, max_per_file_from_linter: 751ns, path_prefixer: 616ns 
INFO [runner] linters took 39.498800358s with stages: goanalysis_metalinter: 31.622377064s, unused: 6.998987728s 
INFO File cache stats: 198 entries of total size 537.2KiB 
INFO Memory: 416 samples, avg is 431.1MB, max is 613.1MB 
INFO Execution took 41.44903011s                  
Found 4 data race(s)
make: *** [Makefile:34: test_race] Error 66
```