### PR TITLE
fix: panic when missing Rows type.

### DIFF
--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -62,7 +62,13 @@ func (r runner) run(pass *analysis.Pass, pkgPath string) (interface{}, error) {
 		return nil, nil
 	}
 
-	r.rowsObj = pkg.Type(rowsName).Object()
+	rowsType := pkg.Type(rowsName)
+	if rowsType == nil {
+		// skip checking
+		return nil, nil
+	}
+
+	r.rowsObj = rowsType.Object()
 	if r.rowsObj == nil {
 		// skip checking
 		return nil, nil


### PR DESCRIPTION
Related to https://github.com/golangci/golangci-lint/issues/1005

```go
package bug

import (
	"github.com/jmoiron/sqlx"
	"github.com/powerman/sqlxx"
)

func Setup() {
	sqlx.NameMapper = sqlxx.ToSnake
}
```


```go
package main

import (
	"github.com/jingyugao/rowserrcheck/passes/rowserr"
	"golang.org/x/tools/go/analysis/singlechecker"
)

func main() {
	singlechecker.Main(rowserr.NewAnalyzer("github.com/powerman/sqlxx"))
}
```
