### PR TITLE
follow sql.Rows across ssa.UnOps

### DIFF
--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -64,7 +64,7 @@ func (r runner) run(pass *analysis.Pass, pkgPath string) {
 	rowsType := pkg.Type(rowsName)
 	if rowsType == nil {
 		// skip checking
-		return nil, nil
+		return
 	}
 
 	r.rowsObj = rowsType.Object()

--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -129,7 +129,6 @@ func (r *runner) errCallMissing(b *ssa.BasicBlock, i int) (ret bool) {
 		errCalled = func(resRef ssa.Instruction) bool {
 			switch resRef := resRef.(type) {
 			case *ssa.Phi:
-				resRefs = append(resRefs, *resRef.Referrers()...)
 				for _, rf := range *resRef.Referrers() {
 					if errCalled(rf) {
 						return true

--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -102,7 +102,7 @@ func (r runner) run(pass *analysis.Pass, pkgPath string) {
 
 		for _, b := range f.Blocks {
 			for i := range b.Instrs {
-				if r.notCheck(b, i) {
+				if r.errCallMissing(b, i) {
 					pass.Reportf(b.Instrs[i].Pos(), "rows.Err must be checked")
 				}
 			}
@@ -110,7 +110,7 @@ func (r runner) run(pass *analysis.Pass, pkgPath string) {
 	}
 }
 
-func (r *runner) notCheck(b *ssa.BasicBlock, i int) (ret bool) {
+func (r *runner) errCallMissing(b *ssa.BasicBlock, i int) (ret bool) {
 	call, ok := r.getCallReturnsRow(b.Instrs[i])
 	if !ok {
 		return false
@@ -161,7 +161,7 @@ func (r *runner) notCheck(b *ssa.BasicBlock, i int) (ret bool) {
 				if f, ok := resRef.Call.Value.(*ssa.Function); ok {
 					for _, b := range f.Blocks {
 						for i := range b.Instrs {
-							return r.notCheck(b, i)
+							return r.errCallMissing(b, i)
 						}
 					}
 				}
@@ -318,7 +318,7 @@ func (r *runner) calledInFunc(f *ssa.Function, called bool) bool {
 					}
 				}
 			default:
-				if r.notCheck(b, i) || !called {
+				if r.errCallMissing(b, i) || !called {
 					return true
 				}
 			}

--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -111,7 +111,7 @@ func (r runner) run(pass *analysis.Pass, pkgPath string) {
 }
 
 func (r *runner) notCheck(b *ssa.BasicBlock, i int) (ret bool) {
-	call, ok := r.getReqCall(b.Instrs[i])
+	call, ok := r.getCallReturnsRow(b.Instrs[i])
 	if !ok {
 		return false
 	}
@@ -193,7 +193,7 @@ func (r *runner) notCheck(b *ssa.BasicBlock, i int) (ret bool) {
 	return true
 }
 
-func (r *runner) getReqCall(instr ssa.Instruction) (*ssa.Call, bool) {
+func (r *runner) getCallReturnsRow(instr ssa.Instruction) (*ssa.Call, bool) {
 	call, ok := instr.(*ssa.Call)
 	if !ok {
 		return nil, false

--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -122,24 +122,22 @@ func (r *runner) errCallMissing(b *ssa.BasicBlock, i int) (ret bool) {
 			continue
 		}
 		if len(*val.Referrers()) == 0 {
-			return true
+			continue
 		}
-
 		resRefs := *val.Referrers()
-		var notCallErr func(resRef ssa.Instruction) bool
-		notCallErr = func(resRef ssa.Instruction) bool {
+		var errCalled func(resRef ssa.Instruction) bool
+		errCalled = func(resRef ssa.Instruction) bool {
 			switch resRef := resRef.(type) {
 			case *ssa.Phi:
 				resRefs = append(resRefs, *resRef.Referrers()...)
 				for _, rf := range *resRef.Referrers() {
-					if !notCallErr(rf) {
-						return false
+					if errCalled(rf) {
+						return true
 					}
 				}
-
 			case *ssa.Store: // Call in Closure function
 				if len(*resRef.Addr.Referrers()) == 0 {
-					return true
+					return false
 				}
 
 				for _, aref := range *resRef.Addr.Referrers() {
@@ -147,21 +145,24 @@ func (r *runner) errCallMissing(b *ssa.BasicBlock, i int) (ret bool) {
 						f := c.Fn.(*ssa.Function)
 						if r.noImportedDBSQL(f) {
 							// skip this
-							return false
+							continue
 						}
 						called := r.isClosureCalled(c)
-
-						return r.calledInFunc(f, called)
+						if r.calledInFunc(f, called) {
+							return true
+						}
 					}
 				}
 			case *ssa.Call: // Indirect function call
 				if r.isErrCall(resRef) {
-					return false
+					return true
 				}
 				if f, ok := resRef.Call.Value.(*ssa.Function); ok {
 					for _, b := range f.Blocks {
 						for i := range b.Instrs {
-							return r.errCallMissing(b, i)
+							if !r.errCallMissing(b, i) {
+								return true
+							}
 						}
 					}
 				}
@@ -174,17 +175,17 @@ func (r *runner) errCallMissing(b *ssa.BasicBlock, i int) (ret bool) {
 
 					for _, ccall := range *bOp.Referrers() {
 						if r.isErrCall(ccall) {
-							return false
+							return true
 						}
 					}
 				}
 			}
 
-			return true
+			return false
 		}
 
 		for _, resRef := range resRefs {
-			if !notCallErr(resRef) {
+			if errCalled(resRef) {
 				return false
 			}
 		}
@@ -311,7 +312,7 @@ func (r *runner) calledInFunc(f *ssa.Function, called bool) bool {
 						if vCall, ok := v.(*ssa.Call); ok {
 							if vCall.Call.Value != nil && vCall.Call.Value.Name() == errMethod {
 								if called {
-									return false
+									return true
 								}
 							}
 						}
@@ -319,10 +320,10 @@ func (r *runner) calledInFunc(f *ssa.Function, called bool) bool {
 				}
 			default:
 				if r.errCallMissing(b, i) || !called {
-					return true
+					return false
 				}
 			}
 		}
 	}
-	return true
+	return false
 }

--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -117,7 +117,7 @@ func (r *runner) notCheck(b *ssa.BasicBlock, i int) (ret bool) {
 	}
 
 	for _, cRef := range *call.Referrers() {
-		val, ok := r.getResVal(cRef)
+		val, ok := r.getRowsVal(cRef)
 		if !ok {
 			continue
 		}
@@ -213,7 +213,7 @@ func (r *runner) getReqCall(instr ssa.Instruction) (*ssa.Call, bool) {
 	return call, true
 }
 
-func (r *runner) getResVal(instr ssa.Instruction) (ssa.Value, bool) {
+func (r *runner) getRowsVal(instr ssa.Instruction) (ssa.Value, bool) {
 	switch instr := instr.(type) {
 	case *ssa.Call:
 		if len(instr.Call.Args) == 1 && types.Identical(instr.Call.Args[0].Type(), r.rowsTyp) {

--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -324,6 +324,5 @@ func (r *runner) calledInFunc(f *ssa.Function, called bool) bool {
 			}
 		}
 	}
-
 	return true
 }

--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -135,12 +135,9 @@ func (r *runner) errCallMissing(b *ssa.BasicBlock, i int) (ret bool) {
 					}
 				}
 			case *ssa.Store: // Call in Closure function
-				if len(*resRef.Addr.Referrers()) == 0 {
-					return false
-				}
-
 				for _, aref := range *resRef.Addr.Referrers() {
-					if c, ok := aref.(*ssa.MakeClosure); ok {
+					switch c := aref.(type) {
+					case *ssa.MakeClosure:
 						f := c.Fn.(*ssa.Function)
 						if r.noImportedDBSQL(f) {
 							// skip this
@@ -149,6 +146,12 @@ func (r *runner) errCallMissing(b *ssa.BasicBlock, i int) (ret bool) {
 						called := r.isClosureCalled(c)
 						if r.calledInFunc(f, called) {
 							return true
+						}
+					case *ssa.UnOp:
+						for _, rf := range *c.Referrers() {
+							if errCalled(rf) {
+								return true
+							}
 						}
 					}
 				}

--- a/passes/rowserr/testdata/src/a/issue16.go
+++ b/passes/rowserr/testdata/src/a/issue16.go
@@ -1,0 +1,12 @@
+package a
+
+func issue16() error {
+	rows, err := db.Query("select 1")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+	}
+	return rows.Err()
+}


### PR DESCRIPTION
The main change in this PR is a fix for #16. However, while working on debugging that change, I found it a bit easier to follow the code by reversing some of the logic.  I've included this refactoring in a set of commits that are hopefully easy to follow.

Previously, code such as the following:

```go
rows, err := db.Query("select 1")
if err != nil {
	return err
}
defer func() { _ = rows.Close() }()
for rows.Next() {}
return rows.Err()
```

would produce a warning despite the clear call to rows.Err(). It appears this is cause by the fact that the closure around rows.Close() induces a level of indirection that we could not follow:

```
func issue16() error:
0:                                                                entry P:0 S:2
	t0 = new *database/sql.Rows (rows)                  **database/sql.Rows
	t1 = *db                                               *database/sql.DB
	t2 = (*database/sql.DB).Query(t1, "select 1":string, nil:[]interface{}...) (*database/sql.Rows, error)
	t3 = extract t2 #0                                   *database/sql.Rows
	*t0 = t3
	t4 = extract t2 #1                                                error
	t5 = t4 != nil:error                                               bool
	if t5 goto 1 else 2
1:                                                              if.then P:1 S:0
	rundefers
	return t4
2:                                                              if.done P:1 S:1
	t6 = make closure issue16$1 [t0]                                 func()
	defer t6()
	jump 5
3:                                                              recover P:0 S:0
	return nil:error
4:                                                             for.done P:1 S:0
	t7 = *t0                                             *database/sql.Rows
	t8 = (*database/sql.Rows).Err(t7)                                 error
	rundefers
	return t8
5:                                                             for.loop P:2 S:2
	t9 = *t0                                             *database/sql.Rows
	t10 = (*database/sql.Rows).Next(t9)                                bool
	if t10 goto 5 else 4
```

The refactor commits rename some functions which previously referred to Close(). Further, and likely the largest change, is that rather it reverses the logic of the main loop. Now, the core closure that is called in the inner loop returns true if Err() is found.  If it never returns true, then we fail the check.

If you'd prefer to avoid this refactor, I understand. In that case, this PR is hopefully just good documentation on the root cause of #16.