### PR TITLE
fix: returns

### DIFF
--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -64,7 +64,7 @@ func (r runner) run(pass *analysis.Pass, pkgPath string) {
 	rowsType := pkg.Type(rowsName)
 	if rowsType == nil {
 		// skip checking
-		return nil, nil
+		return
 	}
 
 	r.rowsObj = rowsType.Object()


### PR DESCRIPTION
The PR #14 has been merged without a rebase on master, the `run` function has a new return signature.

