### PR TITLE
fix: return signature does not match function definition.

### DIFF
--- a/passes/rowserr/rowserr.go
+++ b/passes/rowserr/rowserr.go
@@ -64,7 +64,7 @@ func (r runner) run(pass *analysis.Pass, pkgPath string) {
 	rowsType := pkg.Type(rowsName)
 	if rowsType == nil {
 		// skip checking
-		return nil, nil
+		return
 	}
 
 	r.rowsObj = rowsType.Object()


### PR DESCRIPTION
# Bug

Failure to install during install of `golangci-lint`

```
# github.com/jingyugao/rowserrcheck/passes/rowserr
../../.gvm/pkgsets/go1.16/global/pkg/mod/github.com/jingyugao/rowserrcheck@v0.0.0-20210314081003-080ff0b0c4c0/passes/rowserr/rowserr.go:67:3: too many arguments to return
	have (nil, nil)
	want ()
```

# Fix

Adjust the return signature to match function definition.