### PR TITLE
Add support for external functions handling rows.Err()

### DIFF
--- a/passes/rowserr/testdata/src/a/a.go
+++ b/passes/rowserr/testdata/src/a/a.go
@@ -98,3 +98,41 @@ func f10() {
 	}
 	resCloser(rows)
 }
+
+func standAloneCloser(rs *sql.Rows) {
+	_ = rs.Err()
+}
+
+func f11() {
+	rows, _ := db.Query("") // OK
+	defer standAloneCloser(rows)
+}
+
+func f12() {
+	rows, _ := db.Query("") // OK
+	defer func(rows *sql.Rows) {
+		standAloneCloser(rows)
+	}(rows)
+}
+
+func returningCloser(rs *sql.Rows) error {
+	return rs.Err()
+}
+
+func f13() (err error) {
+	rows, _ := db.Query("") // OK
+	defer func(rows *sql.Rows) {
+		returningCloser(rows)
+	}(rows)
+
+	return err
+}
+
+func f14() (err error) {
+	rows, _ := db.Query("") // OK
+	defer func(rows *sql.Rows) {
+		err = returningCloser(rows)
+	}(rows)
+
+	return err
+}


### PR DESCRIPTION
This adds support for passing rows to a deferred function that checks rows.Err(). It is likely that this could be done differently, I have limited understanding of the internals here, I have merely tried to investigate how this works and written tests that expose the functionality I have been missing.